### PR TITLE
update implicit DatasetFunctions to extend AnyVal

### DIFF
--- a/src/main/scala/com/jakainas/functions/package.scala
+++ b/src/main/scala/com/jakainas/functions/package.scala
@@ -40,7 +40,7 @@ package object functions {
     LocalDate.parse(date, DateTimeFormatter.ISO_DATE).minusDays(-numDays).toString
   }
 
-  implicit class DatasetFunctions[T](val ds: Dataset[T]) {
+  implicit class DatasetFunctions[T](val ds: Dataset[T]) extends AnyVal {
     /**
       * Remove duplicate rows using some column criteria for grouping and ordering
       * @param partCols - How to group rows.  Only 1 row from each group will be in the result
@@ -89,4 +89,5 @@ package object functions {
       case (newDF, (currColName, newColName)) => newDF.withColumnRenamed(currColName, newColName)
     }
   }
+
 }

--- a/src/test/scala/com/jakainas/functions/functionsTest.scala
+++ b/src/test/scala/com/jakainas/functions/functionsTest.scala
@@ -43,12 +43,13 @@ class functionsTest extends SparkTest {
   }
 
   test("addColumns to a DataFrame") {
-    val inputDF = Seq(("a", "b", "c"), ("d", "e", "f")).toDF("dfCol1", "dfCol2", "dfCol3")
+    val inputDF = Seq((1, 2, 3), (2, 4, 8)).toDF("dfCol1", "dfCol2", "dfCol3")
     val resultDF = inputDF.addColumns(("dfCol1plus1", ('dfCol1 + 1)), ("dfCol2x2", ($"dfCol2" * 2)))
+    val expectedDF = Seq((1, 2, 3, 2, 4), (2, 4, 8, 3, 8)).toDF("dfCol1", "dfCol2", "dfCol3", "dfCol1plus1", "dfCol2x2")
 
     // test column names and values are as expected
-    resultDF.columns should contain theSameElementsAs Array("dfCol1", "dfCol2", "dfCol3", "dfCol1plus1", "dfCol2x2")
-    resultDF.where('dfCol1plus1 =!= ('dfCol1 + 1) or 'dfCol2x2 =!= ('dfCol2 * 2)).count shouldEqual 0
+    resultDF.columns should contain theSameElementsAs Array( "dfCol1", "dfCol2", "dfCol3", "dfCol1plus1", "dfCol2x2")
+    resultDF.collect should contain theSameElementsAs expectedDF.collect
 
     // with dataset as well
     Seq(TestData("a", 7), TestData("b", 3)).toDS()


### PR DESCRIPTION
Update implicit DatasetFunctions to extend AnyVal
Fix `addColumn` inputDF data in scalatests